### PR TITLE
Reset login state upon successful signup

### DIFF
--- a/src/main/java/interface_adapter/signup/SignupPresenter.java
+++ b/src/main/java/interface_adapter/signup/SignupPresenter.java
@@ -44,8 +44,11 @@ public class SignupPresenter implements SignupOutputBoundary {
         LocalDateTime responseTime = LocalDateTime.parse(response.getCreationTime());
         response.setCreationTime(responseTime.format(DateTimeFormatter.ofPattern("hh:mm:ss")));
 
-        LoginState loginState = loginViewModel.getState();
+        // Create a fresh login state
+        LoginState loginState = new LoginState();
+
         loginState.setUsername(response.getUsername());
+
         this.loginViewModel.setState(loginState);
         loginViewModel.firePropertyChanged();
 


### PR DESCRIPTION
Fixes #26. LoginState's error message was not being reset after signing up causing the popup for login error to occur when switching to login view (if you previously had an error with login, and went back to signup view)